### PR TITLE
expose db_val=bigarray, change api to support MDB_RESERVE 

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -3,6 +3,7 @@ S tests
 B _build/src
 B _build/tests
 
+PKG bigstringaf
 PKG ctypes
 PKG ctypes.stubs
 PKG ctypes.foreign

--- a/.merlin
+++ b/.merlin
@@ -7,3 +7,4 @@ PKG ctypes
 PKG ctypes.stubs
 PKG ctypes.foreign
 PKG unix-type-representations
+PKG benchmark

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
 matrix:
   include:
   - os: linux
-    env: OCAML_VERSION=4.02
-  - os: linux
     env: OCAML_VERSION=4.03
   - os: linux
     env: OCAML_VERSION=4.04

--- a/_oasis
+++ b/_oasis
@@ -13,7 +13,7 @@ Library lmdb
   Path: src
   Modules: Lmdb
   InternalModules: Lmdb_types, Lmdb_bindings, Lmdb_generated, Lmdb_generated_types
-  BuildDepends: ctypes, ctypes.stubs, ctypes.foreign, unix-type-representations
+  BuildDepends: bigstringaf, ctypes, ctypes.stubs, ctypes.foreign, unix-type-representations
   CCLib: -llmdb
   CSources: lmdb_cstubs.c
 

--- a/lmdb.opam
+++ b/lmdb.opam
@@ -18,6 +18,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "lmdb"]
 depends: [
   "base-bytes"
+  "bigstringaf"
   "ctypes"
   "ctypes-foreign"
   "unix-type-representations"

--- a/src/lmdb.ml
+++ b/src/lmdb.ml
@@ -163,9 +163,13 @@ let trivial_txn ~write env f =
     else Env.Flags.read_only
   in
   mdb_txn_begin env None txn_flag txn ;
-  let x = f !@txn in
-  mdb_txn_commit !@txn ;
-  x
+  try
+    let x = f !@txn in
+    mdb_txn_commit !@txn ;
+    x
+  with e ->
+    mdb_txn_abort !@txn ;
+    raise e
 
 
 module PutFlags = struct

--- a/src/lmdb.ml
+++ b/src/lmdb.ml
@@ -32,7 +32,15 @@ let version () =
 
 type error = int
 
-exception Error = Lmdb_types.Error
+exception Not_found = Lmdb_bindings.Not_found
+exception Exists = Lmdb_bindings.Exists
+exception Error = Lmdb_bindings.Error
+
+let () =
+  Printexc.register_printer @@ function
+  | Error i -> Some ("Lmdb.Error(" ^ mdb_strerror i ^ ")")
+  | Exists -> Some "Lmdb.Exists"
+  | _ -> None
 
 let pp_error fmt i =
   Format.fprintf fmt "%s@." (mdb_strerror i)

--- a/src/lmdb.ml
+++ b/src/lmdb.ml
@@ -67,11 +67,11 @@ module Env = struct
     let env_ptr = alloc mdb_env in
     mdb_env_create env_ptr ;
     let env = !@env_ptr in
-    opt_iter (mdb_env_set_mapsize env) map_size ;
-    opt_iter (mdb_env_set_maxdbs env) max_dbs ;
-    opt_iter (mdb_env_set_maxreaders env) max_readers ;
-    (* mdb_env_set_assert env (fun env s -> raise (Assert (env,s))) ; *)
     try
+      opt_iter (mdb_env_set_mapsize env) map_size ;
+      opt_iter (mdb_env_set_maxdbs env) max_dbs ;
+      opt_iter (mdb_env_set_maxreaders env) max_readers ;
+      (* mdb_env_set_assert env (fun env s -> raise (Assert (env,s))) ; *)
       mdb_env_open env path flags mode ;
       Gc.finalise mdb_env_close env ;
       env

--- a/src/lmdb.ml
+++ b/src/lmdb.ml
@@ -320,11 +320,11 @@ module Make (Key : Values.S) (Elt : Values.S) = struct
     )
 
   let get { db ; env } k =
+    let k' = Key.write k in
     let v = addr @@ make mdb_val in
     trivial_txn ~write:false env (fun t ->
-      mdb_get t db (Key.write k) v)
-    ;
-    Elt.read v
+        mdb_get t db k' v;
+        Elt.read v)
 
   let put ?(flags=PutFlags.none) { db ; env } k v =
     trivial_txn ~write:true env (fun t ->

--- a/src/lmdb.mli
+++ b/src/lmdb.mli
@@ -347,8 +347,10 @@ module IntDb : S with type key = int and type elt = string
 type error = int
 (** Error return code. See Lmdb's documentation for details. *)
 
+exception Exists
+exception Not_found
 exception Error of error
-(** Error are reported with this exception or with {!Not_found}. *)
+(** Errors are reported with those exceptions. *)
 
 val pp_error : Format.formatter -> error -> unit
 (** [pp_error Format.std_formatter e] will print a human-readable description

--- a/src/lmdb.mli
+++ b/src/lmdb.mli
@@ -231,7 +231,9 @@ end
     val stats : 'a txn -> Env.stats
 
     val compare : 'a txn -> key -> key -> int
-    (** The comparison function used by the database. *)
+    val compare_key : 'a txn -> key -> key -> int
+    val compare_elt : 'a txn -> elt -> elt -> int
+    (** The comparison functions used by the database. *)
 
     val drop : ?delete:bool -> [< `Write ] txn -> unit
 
@@ -329,7 +331,9 @@ end
   val drop : ?delete:bool -> t -> unit
 
   val compare : t -> key -> key -> int
-  (** The comparison function used by the database. *)
+  val compare_key : t -> key -> key -> int
+  val compare_elt : t -> elt -> elt -> int
+  (** The comparison functions used by the database. *)
 end
 
 (** Database with string keys and string elements. *)

--- a/src/lmdb.mli
+++ b/src/lmdb.mli
@@ -376,13 +376,14 @@ module Values : sig
     val integer_key : t
   end
 
-  type db_val
+  type db_val =
+    (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
   module type S = sig
     type t
     val default_flags : Flags.t
     val read : db_val -> t
-    val write : t -> db_val
+    val write : (int -> db_val) -> t -> db_val
   end
 
   module Key : sig

--- a/src/lmdb_types.ml
+++ b/src/lmdb_types.ml
@@ -32,7 +32,7 @@ module Make (C : Cstubs.Types.TYPE) = struct
 
   type mdb_val
   let mdb_val : mdb_val structure typ = structure "MDB_val"
-  let mv_size = field mdb_val "mv_size" size_t
+  let mv_size = field mdb_val "mv_size" size_t_as_int
   let mv_data = field mdb_val "mv_data" (ptr void)
   let () = seal mdb_val
 

--- a/src/lmdb_types.ml
+++ b/src/lmdb_types.ml
@@ -1,19 +1,11 @@
 open Unsigned
 open Ctypes
 
-exception Error of int
-
 module Make (C : Cstubs.Types.TYPE) = struct
   open C
 
-  type mdb_error = unit
-  let mdb_error : mdb_error typ =
-    let read = function
-      | 0 -> ()
-      | -30798 -> raise Not_found
-      | i -> raise (Error i)
-    in
-    view ~read ~write:(fun () -> 0) int
+  type mdb_error = int
+  let mdb_error : mdb_error typ = int
 
   let uint_as_int = view ~read:UInt.to_int ~write:UInt.of_int uint
   let size_t_as_int = view ~read:Size_t.to_int ~write:Size_t.of_int size_t

--- a/tests/bench.ml
+++ b/tests/bench.ml
@@ -1,35 +1,39 @@
 open Lmdb
 
-let () =
-  let errors = ref 0 in
-  let env =
-    Env.create
-      ~flags:Env.Flags.(no_subdir + no_sync + write_map + no_lock + no_mem_init)
-      ~map_size:104857600
-      ~max_dbs:1
-      "/tmp/lmdb_bench.db"
-  in
+let errors = ref 0
+let env =
+  Env.create
+    ~flags:Env.Flags.(no_subdir + no_sync + write_map + no_lock + no_mem_init)
+    ~map_size:104857600
+    ~max_dbs:2
+    "/tmp/lmdb_bench.db"
 
-  let map_hostint = IntDb.create ~create:true env "intmap" in
-
+let bench
+    (type key elt)
+    (module Db : S with type key = key and type elt = elt) name key value n =
+  let map_host = Db.create ~create:true env name in
   let bench map cycles =
-    let open IntDb in
+    let open Db in
     drop ~delete:false map;
     for i=0 to cycles-1 do
-      put map i (string_of_int i)
+      put map (key i) (value i)
     done;
     for i=0 to cycles-1 do
-      let v = get map i in
-      if (v <> string_of_int i)
+      let v = get map (key i) in
+      if (v <> value i)
       then incr errors;
     done
   in
+  name, bench map_host, n
 
+let () =   
   let open Benchmark in
   let samples =
     let n = 500 in
-    throughputN ~repeat:5 1
-      [ "IntDb", bench map_hostint, n ]
+    throughputN ~repeat:5 1 [
+      bench (module IntDb) "int" (fun i -> i) string_of_int n ;
+      bench (module Db) "string" string_of_int string_of_int n ;
+    ]
   in
   tabulate samples;
   if !errors > 0


### PR DESCRIPTION
This pull request includes #9.

It does not yet make use of MDB_RESERVE, since I have not yet merged the changes to the functorial interface.

Performance with this interface exposing db_val as bigarray is better than with CArray, even though my benchmark uses very small 8-byte integers / strings as keys / values

Strangely performance improved yet a bit with commit f0ee7f5, which prepares the interface to support MDB_RESERVE:
``` ocaml
val write : (int -> db_val) -> t -> db_val
```
The ``write`` function is passed an allocator, which may simply allocate a bigarray buffer _or_ call a ``mdb_*_put`` function with ``MDB_RESERVE`` and wrap the returned memory region in a bigarray.
If ``write`` calls the allocator it is expected to return the allocated bigarray.
If ``write`` doesn't call the allocator it may return _any_ bigarray and will behave like ``write`` in the old interface. So when implementing a ``write`` function, one may simply ignore the allocator or always use the allocator and the library will decide when to use or not to use ``MDB_RESERVE``.