### PR TITLE
more misc changes by madroach

### DIFF
--- a/tests/test.ml
+++ b/tests/test.ml
@@ -409,10 +409,10 @@ let test_int =
     end
   in
   "Int",
-  [ make_test "int32_be" Map.Conv.int32_be_as_int
-  ; make_test "int32_le" Map.Conv.int32_le_as_int
-  ; make_test "int64_be" Map.Conv.int64_be_as_int
-  ; make_test "int64_le" Map.Conv.int64_le_as_int
+  [ make_test "int32_be" Conv.int32_be_as_int
+  ; make_test "int32_le" Conv.int32_le_as_int
+  ; make_test "int64_be" Conv.int64_be_as_int
+  ; make_test "int64_le" Conv.int64_le_as_int
   ]
 
 let test_stress =


### PR DESCRIPTION
Based on #18.
* remove first-class module converters
* add no-dup iterators
* share implementation of Map.{create,open_existing}
* **try to simplify phantom types**

Now with phantom types removed from Env.t and Map.t, less subtyping casts are required. Some are still needed when creating read-only cursors on read-write environments.

But what to do with ``Txn.go`` and its optional ``perm`` parameter?
If we leave it as-is, the default-behaviour for ``?perm:None`` will be a read-write transaction, even on read-only environments. Is this what we want?
I would rather keep the parameter obligatory and unlabeled. ``Txn.go Ro`` and ``Txn.go Rw`` are concise statements.