### PR TITLE
Remove Ro/Rw phantom type from Env and Map

### DIFF
--- a/src/lmdb.mli
+++ b/src/lmdb.mli
@@ -52,7 +52,7 @@ type 'a perm =
 
 (** Collection of maps stored in a single memory-mapped file. *)
 module Env : sig
-  type -'perm t constraint 'perm = [< `Read | `Write ]
+  type t
 
   module Flags = Mdb.EnvFlags
 
@@ -69,38 +69,36 @@ module Env : sig
       @param mode The UNIX permissions to set on created files and semaphores. Default is [0o755].
   *)
   val create :
-    'perm perm -> ?max_readers:int -> ?map_size:int -> ?max_maps:int ->
-    ?flags:Flags.t -> ?mode:int -> string -> 'perm t
+    _ perm -> ?max_readers:int -> ?map_size:int -> ?max_maps:int ->
+    ?flags:Flags.t -> ?mode:int -> string -> t
 
+  val sync : ?force:bool -> t -> unit
 
+  val close: t -> unit
 
-  val sync : ?force:bool -> [> `Write ] t -> unit
+  val copy : ?compact:bool -> t -> string -> unit
 
-  val close: _ t -> unit
+  val copyfd : ?compact:bool -> t -> Unix.file_descr -> unit
 
-  val copy : ?compact:bool -> [> `Read ] t -> string -> unit
+  val set_flags : t -> Flags.t -> bool -> unit
 
-  val copyfd : ?compact:bool -> [> `Read ] t -> Unix.file_descr -> unit
+  val flags : t -> Flags.t
 
-  val set_flags : 'perm t -> Flags.t -> bool -> unit
+  val set_map_size : t -> int -> unit
 
-  val flags : 'perm t -> Flags.t
+  val path : t -> string
 
-  val set_map_size : [> `Write ] t -> int -> unit
+  val fd : t -> Unix.file_descr
 
-  val path : 'perm t -> string
+  val stats : t -> Mdb.stats
 
-  val fd : 'perm t -> Unix.file_descr
+  val max_readers : t -> int
 
-  val stats : [> `Read ] t -> Mdb.stats
+  val max_keysize : t -> int
 
-  val max_readers : 'perm t -> int
+  val reader_list : t -> string list
 
-  val max_keysize : 'perm t -> int
-
-  val reader_list : 'perm t -> string list
-
-  val reader_check : 'perm t -> int
+  val reader_check : t -> int
 
 end
 
@@ -134,7 +132,7 @@ end
   val go :
     'perm perm ->
     ?txn:'perm t ->
-    'perm Env.t ->
+    Env.t ->
     ('perm t -> 'a) -> 'a option
 
 
@@ -143,7 +141,7 @@ end
   *)
   val abort : 'perm t -> 'b
 
-  val env : 'perm t -> 'perm Env.t
+  val env : 'perm t -> Env.t
   (** [env txn] returns the environment of [txn] *)
 
 end
@@ -256,7 +254,7 @@ module Map : sig
   (** A handle for a map from keys of type ['key] to values of type ['value].
       The map may support only a single value per key ([[ `Dup ]])
       or multiple values per key ([[ `Dup | `Uni ]]). *)
-  type ('key, 'value, -'perm, -'dup) t
+  type ('key, 'value, -'dup) t
     constraint 'perm = [< `Read | `Write ]
     constraint 'dup = [< `Dup | `Uni ]
 
@@ -287,7 +285,7 @@ module Map : sig
     value       :'value Conv.t ->
     ?txn        :[> `Read | `Write ] Txn.t ->
     ?name       :string ->
-    ([> `Read | `Write ] as 'perm) Env.t -> ('key, 'value, 'perm, 'dup) t
+    Env.t -> ('key, 'value, 'dup) t
 
   (** [open_existing env] is like [create], but only opens already existing maps.
       @raise Not_found if the map doesn't exist.
@@ -298,16 +296,16 @@ module Map : sig
     value       :'value Conv.t ->
     ?txn        :[> `Read ] Txn.t ->
     ?name       :string ->
-    ([> `Read ] as 'perm) Env.t ->
-    ('key, 'value, 'perm, 'dup) t
+    Env.t ->
+    ('key, 'value, 'dup) t
 
   (** [env map] returns the environment of [map]. *)
-  val env : (_, _, 'p, _) t -> 'p Env.t
+  val env : _ t -> Env.t
 
   (** [get map key] returns the first value associated to [key].
       @raise Not_found if the key is not in the map.
   *)
-  val get : ('key, 'value, [> `Read ], _) t -> ?txn:[> `Read ] Txn.t -> 'key -> 'value
+  val get : ('key, 'value, _) t -> ?txn:[> `Read ] Txn.t -> 'key -> 'value
 
   module Flags = Lmdb_bindings.PutFlags
 
@@ -321,8 +319,8 @@ module Map : sig
       {! Flags.no_overwrite} or {! Flags.no_dup_data} was passed in
       [flags].
   *)
-  val put : ('key, 'value, ([> `Read | `Write ] as 'perm), _) t ->
-    ?txn:'perm Txn.t -> ?flags:Flags.t -> 'key -> 'value -> unit
+  val put : ('key, 'value, _) t ->
+    ?txn:[> `Write ] Txn.t -> ?flags:Flags.t -> 'key -> 'value -> unit
 
   (** [remove map key] removes [key] from [map].
 
@@ -331,30 +329,30 @@ module Map : sig
 
       @raise Not_found if the key is not in the map.
   *)
-  val remove : ('key, 'value, ([> `Read | `Write ] as 'perm), _) t ->
-    ?txn:'perm Txn.t -> ?value:'value -> 'key -> unit
+  val remove : ('key, 'value, _) t ->
+    ?txn:[> `Write ] Txn.t -> ?value:'value -> 'key -> unit
 
 
   (** {2 Misc} *)
 
-  val stats : ?txn: [> `Read ] Txn.t -> ('key, 'value, [> `Read ], _) t -> Mdb.stats
+  val stats : ?txn: [> `Read ] Txn.t -> ('key, 'value, _) t -> Mdb.stats
 
   (** [drop ?delete map] Empties [map].
       @param delete If [true] [map] is also deleted from the environment
       and the handle [map] invalidated. *)
-  val drop : ?txn: ([> `Read | `Write ] as 'perm) Txn.t -> ?delete:bool ->
-    ('key, 'value, 'perm, _) t -> unit
+  val drop : ?txn: [> `Write ] Txn.t -> ?delete:bool ->
+    ('key, 'value, _) t -> unit
 
   (** [compare_key map ?txn a b]
      Compares [a] and [b] as if they were keys in [map]. *)
-  val compare_key : ('key, 'value, [> `Read ], _) t -> ?txn:[> `Read ] Txn.t -> 'key -> 'key -> int
+  val compare_key : ('key, 'value, _) t -> ?txn:[> `Read ] Txn.t -> 'key -> 'key -> int
 
   (** [compare map ?txn a b] Same as [compare_key]. *)
-  val compare : ('key, 'value, [> `Read ], _) t -> ?txn:[> `Read ] Txn.t -> 'key -> 'key -> int
+  val compare : ('key, 'value, _) t -> ?txn:[> `Read ] Txn.t -> 'key -> 'key -> int
 
   (** [compare_val map ?txn a b]
      Compares [a] and [b] as if they were values in a [dup_sort] [map]. *)
-  val compare_val : ('key, 'value, [> `Read ], [> `Dup ]) t -> ?txn:[> `Read ] Txn.t -> 'value -> 'value -> int
+  val compare_val : ('key, 'value, [> `Dup ]) t -> ?txn:[> `Read ] Txn.t -> 'value -> 'value -> int
 end
 
 (** Iterators over maps. *)
@@ -394,7 +392,7 @@ end
       created before calling [f] and be committed after [f] returns.
       Such a transient transaction may be aborted using {! abort}.
   *)
-  val go : 'perm perm -> ?txn:'perm Txn.t -> ('key, 'value, 'perm, 'dup) Map.t ->
+  val go : 'perm perm -> ?txn:'perm Txn.t -> ('key, 'value, 'dup) Map.t ->
     (('key, 'value, 'perm, 'dup) t -> 'a) -> 'a option
 
   (** [abort cursor] aborts [cursor] and the current [go] function,
@@ -575,53 +573,53 @@ end
       Will call [f] multiple times with the same key for duplicates *)
 
   val iter :
-    ?cursor:('key, 'value, [> `Read ] as 'perm, 'dup) t ->
+    ?cursor:('key, 'value, [> `Read ], 'dup) t ->
     f:('key -> 'value -> unit) ->
-    ('key, 'value, 'perm, 'dup) Map.t ->
+    ('key, 'value, 'dup) Map.t ->
     unit
 
   val iter_rev :
     ?cursor:('key, 'value, [> `Read ] as 'perm, 'dup) t ->
     f:('key -> 'value -> unit) ->
-    ('key, 'value, 'perm, 'dup) Map.t ->
+    ('key, 'value, 'dup) Map.t ->
     unit
 
   val fold_left :
-    ?cursor:('key, 'value, [> `Read ] as 'perm, 'dup) t ->
+    ?cursor:('key, 'value, [> `Read ], 'dup) t ->
     f:('a -> 'key -> 'value -> 'a) -> 'a ->
-    ('key, 'value, 'perm, 'dup) Map.t ->
+    ('key, 'value, 'dup) Map.t ->
     'a
 
   val fold_right :
-    ?cursor:('key, 'value, [> `Read ] as 'perm, 'dup) t ->
+    ?cursor:('key, 'value, [> `Read ], 'dup) t ->
     f:('key -> 'value -> 'a -> 'a) ->
-    ('key, 'value, 'perm, 'dup) Map.t ->
+    ('key, 'value, 'dup) Map.t ->
     'a -> 'a
 
   (** Call [f] once for each key passing the key and {e all} associated values. *)
 
   val iter_all :
-    ?cursor:('key, 'value, [> `Read ] as 'perm, 'dup) t ->
+    ?cursor:('key, 'value, [> `Read ], 'dup) t ->
     f:('key -> 'value array -> unit) ->
-    ('key, 'value, 'perm, [> `Dup ] as  'dup) Map.t ->
+    ('key, 'value, [> `Dup ] as  'dup) Map.t ->
     unit
 
   val iter_rev_all :
     ?cursor:('key, 'value, [> `Read ] as 'perm, 'dup) t ->
     f:('key -> 'value array -> unit) ->
-    ('key, 'value, 'perm, [> `Dup ] as  'dup) Map.t ->
+    ('key, 'value, [> `Dup ] as  'dup) Map.t ->
     unit
 
   val fold_left_all :
-    ?cursor:('key, 'value, [> `Read ] as 'perm, 'dup) t ->
+    ?cursor:('key, 'value, [> `Read ], 'dup) t ->
     f:('a -> 'key -> 'value array -> 'a) -> 'a ->
-    ('key, 'value, 'perm, [> `Dup ] as  'dup) Map.t ->
+    ('key, 'value, [> `Dup ] as  'dup) Map.t ->
     'a
 
   val fold_right_all :
-    ?cursor:('key, 'value, [> `Read ] as 'perm, 'dup) t ->
+    ?cursor:('key, 'value, [> `Read ], 'dup) t ->
     f:('key -> 'value array -> 'a -> 'a) ->
-    ('key, 'value, 'perm, [> `Dup ] as  'dup) Map.t ->
+    ('key, 'value, [> `Dup ] as  'dup) Map.t ->
     'a -> 'a
 end
 

--- a/tests/pr.ml
+++ b/tests/pr.ml
@@ -16,7 +16,7 @@ let test env =
         put_count t count ;
         assert ((Map.stats t).entries = count) ;
         (* Iterate using cursor and print keys *)
-        ignore @@ Lmdb.Cursor.go Ro (t :> (_, _, [ `Read ], _) Map.t) (fun cur ->
+        ignore @@ Lmdb.Cursor.go Ro t (fun cur ->
             (* Triggering GC here also SEGFAULTs *)
             Gc.full_major () ;
             let rec print_keys = function

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -34,8 +34,8 @@ let[@warning "-26-27"] capabilities () =
            ~value:Conv.int32_be_as_int
            ~name:"Capabilities") env
   in
-  let env_rw = (env :> [ `Read | `Write ] Env.t) in
-  let env_ro = (env :> [ `Read ] Env.t) in
+  let env_rw = env in
+  let env_ro = env in
   (* let env_rw = (env_ro :> [ `Read | `Write ] Env.t) in <- FAILS *)
   (* ignore @@ (rw :> [ `Read ] Cap.t); <- FAILS *)
   (* ignore @@ (ro :> [ `Read | `Write ] cap); <- FAILS *)
@@ -45,15 +45,15 @@ let[@warning "-26-27"] capabilities () =
   (* Map.put ~txn:txn_ro map 4 4; <- FAILS *)
   assert (Map.get ~txn:txn_rw map 4 = 4);
   assert (Map.get ~txn:txn_ro map 4 = 4);
-  Cursor.go Ro
-    ~txn:(txn_rw :> [ `Read ] Txn.t)
-    (map :> (_,_,[ `Read ], _) Map.t) @@ fun cursor ->
+  Cursor.go Ro map
+    ~txn:(txn_rw :> [ `Read ] Txn.t) @@ fun cursor ->
   assert (Cursor.get cursor 4 = 4);
   (* Cursor.first_dup cursor; <- FAILS *)
 ;;
 
 
 let check_kv = check (pair int int)
+
 
 let test_nodup =
   "no duplicates",
@@ -176,10 +176,10 @@ let test_dup =
                ~value:Conv.int32_be_as_int
                ~name:"Cursor.wrongmap") env
       in
-      let map2_ro = (map2 :> (_,_,[ `Read ],_) Map.t) in
+      let map2_ro = map2 in
       check_raises "wrong cursor" (Invalid_argument "Lmdb.Cursor.fold: Got cursor for wrong map") begin fun () ->
         ignore @@ Cursor.go Ro map2_ro
-          (fun cursor -> Cursor.fold_left_all ~cursor () (map :> (_,_,[ `Read ],_) Map.t) ~f:(fun _ _ _ -> ()));
+          (fun cursor -> Cursor.fold_left_all ~cursor () map ~f:(fun _ _ _ -> ()));
       end;
       Env.close env2;
     end


### PR DESCRIPTION
This change makes most (all?) subtype casts obsolete.
The only downside is that attempts to write to a read-only environment will error at runtime rather than compiletime.