### PR TITLE
Move Lmdb.Map.Conv to Lmdb.Conv

### DIFF
--- a/src/lmdb.ml
+++ b/src/lmdb.ml
@@ -140,160 +140,160 @@ struct
       | Some x -> x
 end
 
-module Map = struct
-  module Conv = struct
-    type bigstring = Bigstring.t
+module Conv = struct
+  type bigstring = Bigstring.t
 
-    module Flags = Mdb.DbiFlags
+  module Flags = Mdb.DbiFlags
 
-    type 'a t = {
-      flags : Flags.t ;
-      serialise : (int -> Bigstring.t) -> 'a -> Bigstring.t ;
-      deserialise : Bigstring.t -> 'a ;
+  type 'a t = {
+    flags : Flags.t ;
+    serialise : (int -> Bigstring.t) -> 'a -> Bigstring.t ;
+    deserialise : Bigstring.t -> 'a ;
+  }
+
+  let make ?(flags=Flags.none) ~serialise ~deserialise =
+    { flags = flags
+    ; deserialise = deserialise
+    ; serialise = serialise }
+
+  let serialise { serialise; _ } = serialise
+  let deserialise { deserialise; _ } = deserialise
+  let flags { flags; _ } = flags
+
+  let is_int_size n = n = Mdb.sizeof_int || n = Mdb.sizeof_size_t
+
+  let overflow = Invalid_argument "Lmdb: Integer out of bounds"
+
+  let int32_be =
+    { flags =
+        if Sys.big_endian && is_int_size 4
+        then Flags.(integer_key + integer_dup + dup_fixed)
+        else Flags.(dup_fixed)
+    ; serialise = begin fun alloc x ->
+        let a = alloc 4 in
+        Bigstring.set_int32_be a 0 x;
+        a
+      end
+    ; deserialise = begin fun a ->
+        Bigstring.get_int32_be a 0
+      end
     }
 
-    let make ?(flags=Flags.none) ~serialise ~deserialise =
-      { flags = flags
-      ; deserialise = deserialise
-      ; serialise = serialise }
+  let int32_le =
+    { flags =
+        if not Sys.big_endian && is_int_size 4
+        then Flags.(integer_key + integer_dup + dup_fixed)
+        else Flags.(reverse_key + reverse_dup + dup_fixed)
+    ; serialise = begin fun alloc x ->
+        let a = alloc 4 in
+        Bigstring.set_int32_le a 0 x;
+        a
+      end
+    ; deserialise = begin fun a ->
+        Bigstring.get_int32_le a 0
+      end
+    }
 
-    let serialise { serialise; _ } = serialise
-    let deserialise { deserialise; _ } = deserialise
-    let flags { flags; _ } = flags
+  let int32_as_int { flags; deserialise; serialise } =
+    { flags
+    ; serialise = begin
+        if Sys.int_size <= 32
+        then fun alloc i ->
+          serialise alloc @@ Int32.of_int i
+        else fun alloc i ->
+          let ix = Int32.of_int i in
+          if Int32.to_int ix = i
+          then serialise alloc ix
+          else raise overflow
+      end
+    ; deserialise = begin
+        if Sys.int_size >= 32
+        then fun a ->
+          deserialise a |> Int32.to_int
+        else fun a ->
+          let ix = deserialise a in
+          let i = Int32.to_int ix in
+          if Int32.of_int i = ix
+          then i
+          else raise overflow
+      end
+    }
 
-    let is_int_size n = n = Mdb.sizeof_int || n = Mdb.sizeof_size_t
+  let int32_be_as_int = int32_as_int int32_be
+  let int32_le_as_int = int32_as_int int32_le
 
-    let overflow = Invalid_argument "Lmdb: Integer out of bounds"
+  let int64_be =
+    { flags =
+        if Sys.big_endian && is_int_size 8
+        then Flags.(integer_key + integer_dup + dup_fixed)
+        else Flags.(dup_fixed)
+    ; serialise = begin fun alloc x ->
+        let a = alloc 8 in
+        Bigstring.set_int64_be a 0 x;
+        a
+      end
+    ; deserialise = begin fun a ->
+        Bigstring.get_int64_be a 0
+      end
+    }
 
-    let int32_be =
-      { flags =
-          if Sys.big_endian && is_int_size 4
-          then Flags.(integer_key + integer_dup + dup_fixed)
-          else Flags.(dup_fixed)
-      ; serialise = begin fun alloc x ->
-          let a = alloc 4 in
-          Bigstring.set_int32_be a 0 x;
-          a
-        end
-      ; deserialise = begin fun a ->
-          Bigstring.get_int32_be a 0
-        end
-      }
+  let int64_le =
+    { flags =
+        if not Sys.big_endian && is_int_size 8
+        then Flags.(integer_key + integer_dup + dup_fixed)
+        else Flags.(reverse_key + reverse_dup + dup_fixed)
+    ; serialise = begin fun alloc x ->
+        let a = alloc 8 in
+        Bigstring.set_int64_le a 0 x;
+        a
+      end
+    ; deserialise = begin fun a ->
+        Bigstring.get_int64_le a 0
+      end
+    }
 
-    let int32_le =
-      { flags =
-          if not Sys.big_endian && is_int_size 4
-          then Flags.(integer_key + integer_dup + dup_fixed)
-          else Flags.(reverse_key + reverse_dup + dup_fixed)
-      ; serialise = begin fun alloc x ->
-          let a = alloc 4 in
-          Bigstring.set_int32_le a 0 x;
-          a
-        end
-      ; deserialise = begin fun a ->
-          Bigstring.get_int32_le a 0
-        end
-      }
+  let int64_as_int { flags; deserialise; serialise } =
+    { flags
+    ; serialise = begin fun alloc i ->
+        serialise alloc @@ Int64.of_int i
+      end
+    ; deserialise = begin
+        if Sys.int_size >= 64
+        then fun a ->
+          deserialise a |> Int64.to_int
+        else fun a ->
+          let ix = deserialise a in
+          let i = Int64.to_int ix in
+          if Int64.of_int i = ix
+          then i
+          else raise overflow
+      end
+    }
 
-    let int32_as_int { flags; deserialise; serialise } =
-      { flags
-      ; serialise = begin
-          if Sys.int_size <= 32
-          then fun alloc i ->
-            serialise alloc @@ Int32.of_int i
-          else fun alloc i ->
-            let ix = Int32.of_int i in
-            if Int32.to_int ix = i
-            then serialise alloc ix
-            else raise overflow
-        end
-      ; deserialise = begin
-          if Sys.int_size >= 32
-          then fun a ->
-            deserialise a |> Int32.to_int
-          else fun a ->
-            let ix = deserialise a in
-            let i = Int32.to_int ix in
-            if Int32.of_int i = ix
-            then i
-            else raise overflow
-        end
-      }
+  let int64_be_as_int = int64_as_int int64_be
+  let int64_le_as_int = int64_as_int int64_le
 
-    let int32_be_as_int = int32_as_int int32_be
-    let int32_le_as_int = int32_as_int int32_le
+  let string =
+    { flags = Flags.none
+    ; serialise = begin fun alloc s ->
+        let len = String.length s in
+        let a = alloc len in
+        Bigstring.blit_from_string s ~src_off:0 a ~dst_off:0 ~len;
+        a
+      end
+    ; deserialise = begin fun a ->
+        Bigstring.substring a ~off:0 ~len:(Bigstring.length a)
+      end
+    }
 
-    let int64_be =
-      { flags =
-          if Sys.big_endian && is_int_size 8
-          then Flags.(integer_key + integer_dup + dup_fixed)
-          else Flags.(dup_fixed)
-      ; serialise = begin fun alloc x ->
-          let a = alloc 8 in
-          Bigstring.set_int64_be a 0 x;
-          a
-        end
-      ; deserialise = begin fun a ->
-          Bigstring.get_int64_be a 0
-        end
-      }
+  let bigstring =
+    { flags = Flags.none
+    ; serialise = (fun _ b -> b)
+    ; deserialise = (fun b -> b)
+    }
+end
 
-    let int64_le =
-      { flags =
-          if not Sys.big_endian && is_int_size 8
-          then Flags.(integer_key + integer_dup + dup_fixed)
-          else Flags.(reverse_key + reverse_dup + dup_fixed)
-      ; serialise = begin fun alloc x ->
-          let a = alloc 8 in
-          Bigstring.set_int64_le a 0 x;
-          a
-        end
-      ; deserialise = begin fun a ->
-          Bigstring.get_int64_le a 0
-        end
-      }
-
-    let int64_as_int { flags; deserialise; serialise } =
-      { flags
-      ; serialise = begin fun alloc i ->
-          serialise alloc @@ Int64.of_int i
-        end
-      ; deserialise = begin
-          if Sys.int_size >= 64
-          then fun a ->
-            deserialise a |> Int64.to_int
-          else fun a ->
-            let ix = deserialise a in
-            let i = Int64.to_int ix in
-            if Int64.of_int i = ix
-            then i
-            else raise overflow
-        end
-      }
-
-    let int64_be_as_int = int64_as_int int64_be
-    let int64_le_as_int = int64_as_int int64_le
-
-    let string =
-      { flags = Flags.none
-      ; serialise = begin fun alloc s ->
-          let len = String.length s in
-          let a = alloc len in
-          Bigstring.blit_from_string s ~src_off:0 a ~dst_off:0 ~len;
-          a
-        end
-      ; deserialise = begin fun a ->
-          Bigstring.substring a ~off:0 ~len:(Bigstring.length a)
-        end
-      }
-
-    let bigstring =
-      { flags = Flags.none
-      ; serialise = (fun _ b -> b)
-      ; deserialise = (fun b -> b)
-      }
-  end
-
+module Map = struct
   type ('k, 'v, -'perm, -'dup) t =
     { env               :'perm Env.t
     ; mutable dbi       :Mdb.dbi
@@ -579,7 +579,7 @@ module Cursor = struct
 
   let get_values_multiple cursor len =
     let value = cursor.map.value in
-    assert Map.Conv.Flags.(test dup_fixed cursor.map.flags);
+    assert Conv.Flags.(test dup_fixed cursor.map.flags);
     let _, first = cursor_none cursor Ops.first_dup in
     let size = Bigstring.length first in
     let values = Array.make len (Obj.magic ()) in
@@ -610,11 +610,11 @@ module Cursor = struct
 
 
   let get_values_from_first cursor first =
-    if not Map.Conv.Flags.(test dup_sort cursor.map.flags)
+    if not Conv.Flags.(test dup_sort cursor.map.flags)
     then [| first |]
     else begin
       let len = Mdb.cursor_count cursor.cursor in
-      if len > 1 && Map.Conv.Flags.(test (dup_sort + dup_fixed) cursor.map.flags)
+      if len > 1 && Conv.Flags.(test (dup_sort + dup_fixed) cursor.map.flags)
       then get_values_multiple cursor len
       else begin
         let values = Array.make len first in
@@ -626,11 +626,11 @@ module Cursor = struct
     end
 
   let get_values_from_last cursor last =
-    if not Map.Conv.Flags.(test dup_sort cursor.map.flags)
+    if not Conv.Flags.(test dup_sort cursor.map.flags)
     then [| last |]
     else begin
       let len = Mdb.cursor_count cursor.cursor in
-      if len > 1 && Map.Conv.Flags.(test (dup_sort + dup_fixed) cursor.map.flags)
+      if len > 1 && Conv.Flags.(test (dup_sort + dup_fixed) cursor.map.flags)
       then begin
         let values = get_values_multiple cursor len in
         cursor_none cursor Ops.first_dup |> ignore;
@@ -668,7 +668,7 @@ module Cursor = struct
 
   let put_raw_key { cursor ; map } ~flags ka v =
     let value = map.value in
-    if Map.Conv.Flags.(test dup_sort map.flags)
+    if Conv.Flags.(test dup_sort map.flags)
     then begin
       let va = value.serialise Bigstring.create v in
       Mdb.cursor_put cursor ka va flags

--- a/src/lmdb.mli
+++ b/src/lmdb.mli
@@ -148,111 +148,111 @@ end
 
 end
 
+(** Converters to and from the internal representation of keys and values.
+    A converter contains serialising and deserialising functions as well as
+    the flags applied when the converter is used in a map.
+*)
+module Conv : sig
+  (** {2 Types } *)
+
+  type 'a t
+
+  type bigstring =
+    (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+  (** Bigstrings are used to transfer the raw serialised data into and out of
+      the database. They may point directly to a memory-mapped region of the
+      database file. *)
+
+  (** Flags describing the (sorting) properties of keys and values of a map.
+
+      See the LMDB documentation for the meaning of these flags.
+
+      You probably won't need those flags since the converters provided in
+      {!Conv} will already make appropriate use of these flags.
+  *)
+  module Flags = Lmdb_bindings.DbiFlags
+
+  (** {2 Constructor and accessors} *)
+
+  val make :
+    ?flags:Flags.t ->
+    serialise:((int -> bigstring) -> 'a -> bigstring) ->
+    deserialise:(bigstring -> 'a) ->
+    'a t
+  (** [make ~serialise ~deserialise]
+      creates a converter from a serialising and a deserialising function
+
+      @param serialise [serialise alloc x]
+        {e may} call [alloc len] {e once} to allocate a [bigstring] of size [len].
+        It then {e must} fill the serialised data of [x] into this [bigstring]
+        and return {e exactly this} bigstring. If [serialise] didn't call [alloc] it may
+        return any [bigstring].
+        [alloc] may return uninitialised memory. It is therefore recommended
+        that [serialise] overwrites all allocated memory to avoid leaking possibly
+        sensitive memory content into the database.
+
+        If [serialise] calls [alloc] the library may utilise the [MDB_RESERVE]
+        interface when appropriate to avoid calls to [malloc] and [memcpy].
+
+      @param deserialise
+        The passed {!bigstring} is only valid as long as the current transaction.
+        It is therefore strongly recommended not to leak it out of [deserialise].
+
+      @param flags Flags to be set on a map using this converter.
+
+        Depending on the use of a converter as {e key} or {e value}
+        {!Map.create} and {!Map.open_existing} will select the correct set of
+        flags: [_key] flags will be used for keys and [_dup] flags will be
+        used for values on maps supporting duplicates.
+
+  *)
+
+  val serialise : 'a t -> (int -> bigstring) -> 'a -> bigstring
+  val deserialise : 'a t -> bigstring -> 'a
+  val flags : _ t -> Flags.t
+
+  (** {2 Predefined converters } *)
+
+  (** {3 Strings } *)
+
+  val bigstring :bigstring t
+  (** The [bigstring] converter returns bigstrings as returned by the lmdb
+      backend. These bigstrings point into the environment memory-map and
+      are therefore only guaranteed to be valid until the transaction ends.
+      If you need longer-lived values then use the [string] converter, make a copy
+      or write a custom converter.
+  *)
+
+  val string :string t
+  (** The [string] converter simply copies the raw database content from / to
+      OCaml strings. *)
+
+
+  (** {3 Integers } *)
+
+  (** The integer converters will make use of {! Flags.t} as
+      appropriate so that integers are sorted in ascending order irrespective
+      of machine endianness.
+  *)
+
+  val int32_be        :Int32.t t
+  val int64_be        :Int64.t t
+  val int32_le        :Int32.t t
+  val int64_le        :Int64.t t
+
+  (** For convenience, the [_as_int] converters convert the internal integer
+      representation to and from [int].
+      @raise Invalid_argument [Invalid_argument "Lmdb: Integer out of bounds"]
+  *)
+
+  val int32_be_as_int :int t
+  val int64_be_as_int :int t
+  val int32_le_as_int :int t
+  val int64_le_as_int :int t
+end
+
 (** Key-value maps. *)
 module Map : sig
-  (** Converters to and from the internal representation of keys and values.
-      A converter contains serialising and deserialising functions as well as
-      the flags applied when the converter is used in a map.
-  *)
-  module Conv : sig
-    (** {2 Types } *)
-
-    type 'a t
-
-    type bigstring =
-      (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
-    (** Bigstrings are used to transfer the raw serialised data into and out of
-        the database. They may point directly to a memory-mapped region of the
-        database file. *)
-
-    (** Flags describing the (sorting) properties of keys and values of a map.
-
-        See the LMDB documentation for the meaning of these flags.
-
-        You probably won't need those flags since the converters provided in
-        {!Conv} will already make appropriate use of these flags.
-    *)
-    module Flags = Lmdb_bindings.DbiFlags
-
-    (** {2 Constructor and accessors} *)
-
-    val make :
-      ?flags:Flags.t ->
-      serialise:((int -> bigstring) -> 'a -> bigstring) ->
-      deserialise:(bigstring -> 'a) ->
-      'a t
-    (** [make ~serialise ~deserialise]
-        creates a converter from a serialising and a deserialising function
-
-        @param serialise [serialise alloc x]
-          {e may} call [alloc len] {e once} to allocate a [bigstring] of size [len].
-          It then {e must} fill the serialised data of [x] into this [bigstring]
-          and return {e exactly this} bigstring. If [serialise] didn't call [alloc] it may
-          return any [bigstring].
-          [alloc] may return uninitialised memory. It is therefore recommended
-          that [serialise] overwrites all allocated memory to avoid leaking possibly
-          sensitive memory content into the database.
-
-          If [serialise] calls [alloc] the library may utilise the [MDB_RESERVE]
-          interface when appropriate to avoid calls to [malloc] and [memcpy].
-
-        @param deserialise
-          The passed {!bigstring} is only valid as long as the current transaction.
-          It is therefore strongly recommended not to leak it out of [deserialise].
-
-        @param flags Flags to be set on a map using this converter.
-
-          Depending on the use of a converter as {e key} or {e value}
-          {!Map.create} and {!Map.open_existing} will select the correct set of
-          flags: [_key] flags will be used for keys and [_dup] flags will be
-          used for values on maps supporting duplicates.
-
-    *)
-
-    val serialise : 'a t -> (int -> bigstring) -> 'a -> bigstring
-    val deserialise : 'a t -> bigstring -> 'a
-    val flags : _ t -> Flags.t
-
-    (** {2 Predefined converters } *)
-
-    (** {3 Strings } *)
-
-    val bigstring :bigstring t
-    (** The [bigstring] converter returns bigstrings as returned by the lmdb
-        backend. These bigstrings point into the environment memory-map and
-        are therefore only guaranteed to be valid until the transaction ends.
-        If you need longer-lived values then use the [string] converter, make a copy
-        or write a custom converter.
-    *)
-
-    val string :string t
-    (** The [string] converter simply copies the raw database content from / to
-        OCaml strings. *)
-
-
-    (** {3 Integers } *)
-
-    (** The integer converters will make use of {! Flags.t} as
-        appropriate so that integers are sorted in ascending order irrespective
-        of machine endianness.
-    *)
-
-    val int32_be        :Int32.t t
-    val int64_be        :Int64.t t
-    val int32_le        :Int32.t t
-    val int64_le        :Int64.t t
-
-    (** For convenience, the [_as_int] converters convert the internal integer
-        representation to and from [int].
-        @raise Invalid_argument [Invalid_argument "Lmdb: Integer out of bounds"]
-    *)
-
-    val int32_be_as_int :int t
-    val int64_be_as_int :int t
-    val int32_le_as_int :int t
-    val int64_le_as_int :int t
-  end
-
   (** A handle for a map from keys of type ['key] to values of type ['value].
       The map may support only a single value per key ([[ `Dup ]])
       or multiple values per key ([[ `Dup | `Uni ]]). *)

--- a/tests/bench.ml
+++ b/tests/bench.ml
@@ -11,7 +11,7 @@ let benchmark repeat =
   let errors = ref 0 in
 
   let bench name conv_key conv_val key value n =
-    let map = Map.(create nodup ~key:conv_key ~value:conv_val) env ~name in
+    let map = Map.(create Nodup ~key:conv_key ~value:conv_val) env ~name in
     let bench map cycles =
       let open Map in
       for i=0 to cycles-1 do
@@ -31,11 +31,11 @@ let benchmark repeat =
   let samples =
     let n = 500 in
     throughputN ~repeat 1
-      [ bench "string"   Map.Conv.string   Map.Conv.string string_of_int string_of_int n
-      ; bench "int32_be" Map.Conv.int32_be Map.Conv.string Int32.of_int string_of_int n
-      ; bench "int32_le" Map.Conv.int32_le Map.Conv.string Int32.of_int string_of_int n
-      ; bench "int64_be" Map.Conv.int64_be Map.Conv.string Int64.of_int string_of_int n
-      ; bench "int64_le" Map.Conv.int64_le Map.Conv.string Int64.of_int string_of_int n
+      [ bench "string"   Conv.string   Conv.string string_of_int string_of_int n
+      ; bench "int32_be" Conv.int32_be Conv.string Int32.of_int string_of_int n
+      ; bench "int32_le" Conv.int32_le Conv.string Int32.of_int string_of_int n
+      ; bench "int64_be" Conv.int64_be Conv.string Int64.of_int string_of_int n
+      ; bench "int64_le" Conv.int64_le Conv.string Int64.of_int string_of_int n
       ]
   in
   tabulate samples;

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -409,10 +409,10 @@ let test_int =
     end
   in
   "Int",
-  [ make_test "int32_be" Map.Conv.int32_be_as_int
-  ; make_test "int32_le" Map.Conv.int32_le_as_int
-  ; make_test "int64_be" Map.Conv.int64_be_as_int
-  ; make_test "int64_le" Map.Conv.int64_le_as_int
+  [ make_test "int32_be" Conv.int32_be_as_int
+  ; make_test "int32_le" Conv.int32_le_as_int
+  ; make_test "int64_be" Conv.int64_be_as_int
+  ; make_test "int64_le" Conv.int64_le_as_int
   ]
 
 let test_stress =


### PR DESCRIPTION
Which is better?
``Lmdb.Map.Conv``, so that one will write
```ocaml
Map.(open_existing Nodup ~key:Conv.string ~value:Conv.string) env
```
or ``Lmdb.Conv``, so that one may also write
```ocaml
Map.open_existing Nodup ~key:Conv.string ~value:Conv.string env
```