### PR TITLE
Don't return options on Txn.go and Cursor.go

### DIFF
--- a/tests/pr.ml
+++ b/tests/pr.ml
@@ -16,7 +16,7 @@ let test env =
         put_count t count ;
         assert ((Map.stats t).entries = count) ;
         (* Iterate using cursor and print keys *)
-        ignore @@ Lmdb.Cursor.go Ro (t :> (_, _, [ `Read ], _) Map.t) (fun cur ->
+        ignore @@ Lmdb.Cursor.go Ro (t :> (_, _, [ `Read ], _) Map.t) (fun _ cur ->
             (* Triggering GC here also SEGFAULTs *)
             Gc.full_major () ;
             let rec print_keys = function


### PR DESCRIPTION
instead pass a custom abort function to the user which will take as
argument the value to return after aborting.