### PR TITLE
1. Remove Cursor.abort  2. flexible return type for abort

### DIFF
--- a/src/lmdb.mli
+++ b/src/lmdb.mli
@@ -139,7 +139,7 @@ end
   (** [abort txn] aborts transaction [txn] and the current [go] function,
       which will return [None].
   *)
-  val abort : 'perm t -> 'b
+  val abort : _ t -> _
 
   val env : 'perm t -> Env.t
   (** [env txn] returns the environment of [txn] *)

--- a/src/lmdb.mli
+++ b/src/lmdb.mli
@@ -390,17 +390,9 @@ end
 
       @param txn if omitted a transient transaction will implicitely be
       created before calling [f] and be committed after [f] returns.
-      Such a transient transaction may be aborted using {! abort}.
   *)
   val go : 'perm perm -> ?txn:'perm Txn.t -> ('key, 'value, 'dup) Map.t ->
-    (('key, 'value, 'perm, 'dup) t -> 'a) -> 'a option
-
-  (** [abort cursor] aborts [cursor] and the current [go] function,
-      which will return [None].
-      @raise Invalid_argument if a transaction [~txn] was passed to the [go]
-      function.
-  *)
-  val abort : _ t -> unit
+    (('key, 'value, 'perm, 'dup) t -> 'a) -> 'a
 
 
   (** {2 Modification} *)


### PR DESCRIPTION
This PR has two changes that should be reviewed separately:

1. Remove ``Cursor.abort``, because it is only safe if the transaction was created by ``Cursor.abort``. We already error out if a cursor with custom transaction is aborted. I believe it is better to require explicit creation of a transaction when the user wants to abort a transaction. Transactions and Cursors are different things with different scopes. Don't pretend otherwise.
2. Since ``Txn.abort`` doesn't return, make the return type flexible. This matches the behaviour of ``raise`` and ``assert false``.