### PR TITLE
Update and strip down list of tested OCaml versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,10 @@ env:
 matrix:
   include:
   - os: osx
-    env: OCAML_VERSION=4.07
+    env: OCAML_VERSION=4.09
   - os: linux
-    env: OCAML_VERSION=4.07 DOC=true
+    env: OCAML_VERSION=4.09 DOC=true
   - os: linux
     env: OCAML_VERSION=4.03
   - os: linux
-    env: OCAML_VERSION=4.04
-  - os: linux
     env: OCAML_VERSION=4.05
-  - os: linux
-    env: OCAML_VERSION=4.06


### PR DESCRIPTION
test earliest supported version 4.03,
version used by debian / ubuntu 4.05,
latest OCaml 4.09