### PR TITLE
depend on dune-configurator

### DIFF
--- a/lmdb.opam
+++ b/lmdb.opam
@@ -20,6 +20,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "bigstringaf"
   "dune" {build}
+  "dune-configurator" {build}
   "alcotest" {with-test}
   "benchmark" {with-test}
   "odoc" {with-doc}

--- a/src/lmdb_stubs.c
+++ b/src/lmdb_stubs.c
@@ -20,7 +20,6 @@
 #include <lmdb.h>
 
 #define CAML_NAME_SPACE
-#define CAML_SAFE_STRING
 #include <caml/mlvalues.h>
 #include <caml/threads.h>
 #include <caml/alloc.h>


### PR DESCRIPTION
dune-configurator has been split off from dune.
Also remove ``CAML_SAFE_STRING`` from stubs, because it is now defined by default in the caml runtime headers.