### PR TITLE
On OpenBSD and NetBSD alloca() is declared in stdlib.h

### DIFF
--- a/src/lmdb_stubs.c
+++ b/src/lmdb_stubs.c
@@ -17,7 +17,7 @@
 
 #ifdef _WIN32
 #include <malloc.h>
-#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFlyBSD__)
 #include <stdlib.h>
 #else
 #include <alloca.h>

--- a/src/lmdb_stubs.c
+++ b/src/lmdb_stubs.c
@@ -17,7 +17,7 @@
 
 #ifdef _WIN32
 #include <malloc.h>
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #include <stdlib.h>
 #else
 #include <alloca.h>


### PR DESCRIPTION
Similarly to #48, we add support for some other BSDs. I don't have access to `DragonFlyBSD` but presumably something similar might need to be done there. I've left that out since I cannot verify it.

Tested on:
- [x] OpenBSD
- [x] NetBSD